### PR TITLE
Separate Token Estimators For OpenAI Models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Response` class `estimate_tokens` method
 - `universal_tokens_estimator` function
 - `openai_tokens_estimator_gpt35_turbo` function
-- `openai_tokens_estimator_gpt35_turbo` function
+- `openai_tokens_estimator_gpt4` function
 ### Changed
 - `init_check` parameter added to `Prompt` class
 - `init_check` parameter added to `Session` class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Prompt` class `estimate_tokens` method
 - `Response` class `estimate_tokens` method
 - `universal_tokens_estimator` function
-- `openai_tokens_estimator_gpt35_turbo` function
-- `openai_tokens_estimator_gpt4` function
+- `openai_tokens_estimator_gpt_3_5` function
+- `openai_tokens_estimator_gpt_4` function
 ### Changed
 - `init_check` parameter added to `Prompt` class
 - `init_check` parameter added to `Session` class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Prompt` class `estimate_tokens` method
 - `Response` class `estimate_tokens` method
 - `universal_tokens_estimator` function
-- `openai_tokens_estimator` function
+- `openai_tokens_estimator_gpt35_turbo` function
+- `openai_tokens_estimator_gpt35_turbo` function
 ### Changed
 - `init_check` parameter added to `Prompt` class
 - `init_check` parameter added to `Session` class

--- a/memor/tokens_estimator.py
+++ b/memor/tokens_estimator.py
@@ -135,7 +135,7 @@ def _openai_tokens_estimator(text: str) -> int:
     return token_estimate
 
 
-def openai_tokens_estimator_gpt35_turbo(text: str) -> int:
+def openai_tokens_estimator_gpt_3_5(text: str) -> int:
     """
     Estimate the number of tokens in a given text for OpenAI's GPT-3.5 Turbo model.
 
@@ -146,7 +146,7 @@ def openai_tokens_estimator_gpt35_turbo(text: str) -> int:
     return int(max(1, token_estimate))
 
 
-def openai_tokens_estimator_gpt4(text: str) -> int:
+def openai_tokens_estimator_gpt_4(text: str) -> int:
     """
     Estimate the number of tokens in a given text for OpenAI's GPT-4 model.
 
@@ -162,6 +162,6 @@ class TokensEstimator(Enum):
     """Token estimator enum."""
 
     UNIVERSAL = universal_tokens_estimator
-    OPENAI_GPT35_TURBO = openai_tokens_estimator_gpt35_turbo
-    OPENAI_GPT4 = openai_tokens_estimator_gpt4
+    OPENAI_GPT_3_5 = openai_tokens_estimator_gpt_3_5
+    OPENAI_GPT_4 = openai_tokens_estimator_gpt_4
     DEFAULT = UNIVERSAL

--- a/memor/tokens_estimator.py
+++ b/memor/tokens_estimator.py
@@ -103,12 +103,11 @@ def universal_tokens_estimator(message: str) -> int:
             COMMON_SUFFIXES) for token in tokens)
 
 
-def openai_tokens_estimator(text: str, model: str = "gpt-3.5-turbo") -> int:
+def _openai_tokens_estimator(text: str) -> int:
     """
-    Estimate the number of tokens in a given text for a specified OpenAI model.
+    Estimate the number of tokens in a given text for OpenAI's models.
 
     :param text: The input text to estimate tokens for.
-    :param model: The OpenAI model name (default is 'gpt-3.5-turbo').
     :return: Estimated number of tokens.
     """
     if not isinstance(text, str):
@@ -136,8 +135,29 @@ def openai_tokens_estimator(text: str, model: str = "gpt-3.5-turbo") -> int:
     rare_char_count = sum(1 for char in text if ord(char) > 10000)
     token_estimate += rare_char_count * 0.8
 
-    if "gpt-4" in model.lower():
-        token_estimate *= 1.05
+    return token_estimate
+
+
+def openai_tokens_estimator_gpt35_turbo(text: str) -> int:
+    """
+    Estimate the number of tokens in a given text for OpenAI's GPT-3.5 Turbo model.
+
+    :param text: The input text to estimate tokens for.
+    :return: Estimated number of tokens.
+    """
+    token_estimate = _openai_tokens_estimator(text)
+    return int(max(1, token_estimate))
+
+
+def openai_tokens_estimator_gpt4(text: str) -> int:
+    """
+    Estimate the number of tokens in a given text for OpenAI's GPT-4 model.
+
+    :param text: The input text to estimate tokens for.
+    :return: Estimated number of tokens.
+    """
+    token_estimate = _openai_tokens_estimator(text)
+    token_estimate *= 1.05 # Adjusting for GPT-4's tokenization
     return int(max(1, token_estimate))
 
 
@@ -145,5 +165,6 @@ class TokensEstimator(Enum):
     """Token estimator enum."""
 
     UNIVERSAL = universal_tokens_estimator
-    OPENAI = openai_tokens_estimator
+    OPENAI_GPT35_TURBO = openai_tokens_estimator_gpt35_turbo
+    OPENAI_GPT4 = openai_tokens_estimator_gpt4
     DEFAULT = UNIVERSAL

--- a/memor/tokens_estimator.py
+++ b/memor/tokens_estimator.py
@@ -110,9 +110,6 @@ def _openai_tokens_estimator(text: str) -> int:
     :param text: The input text to estimate tokens for.
     :return: Estimated number of tokens.
     """
-    if not isinstance(text, str):
-        return 0
-
     char_count = len(text)
     token_estimate = char_count / 4
 

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -55,7 +55,12 @@ def test_estimated_tokens1():
 
 def test_estimated_tokens2():
     prompt = Prompt(message="Hello, how are you?", role=Role.USER)
-    assert prompt.estimate_tokens(TokensEstimator.OPENAI) == 7
+    assert prompt.estimate_tokens(TokensEstimator.OPENAI_GPT35_TURBO) == 7
+
+
+def test_estimated_tokens3():
+    prompt = Prompt(message="Hello, how are you?", role=Role.USER)
+    assert prompt.estimate_tokens(TokensEstimator.OPENAI_GPT4) == 8
 
 
 def test_role1():

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -55,12 +55,12 @@ def test_estimated_tokens1():
 
 def test_estimated_tokens2():
     prompt = Prompt(message="Hello, how are you?", role=Role.USER)
-    assert prompt.estimate_tokens(TokensEstimator.OPENAI_GPT35_TURBO) == 7
+    assert prompt.estimate_tokens(TokensEstimator.OPENAI_GPT_3_5) == 7
 
 
 def test_estimated_tokens3():
     prompt = Prompt(message="Hello, how are you?", role=Role.USER)
-    assert prompt.estimate_tokens(TokensEstimator.OPENAI_GPT4) == 8
+    assert prompt.estimate_tokens(TokensEstimator.OPENAI_GPT_4) == 8
 
 
 def test_role1():

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -49,7 +49,12 @@ def test_estimated_tokens1():
 
 def test_estimated_tokens2():
     response = Response(message="I am fine.")
-    assert response.estimate_tokens(TokensEstimator.OPENAI) == 4
+    assert response.estimate_tokens(TokensEstimator.OPENAI_GPT35_TURBO) == 4
+
+
+def test_estimated_tokens3():
+    response = Response(message="I am fine.")
+    assert response.estimate_tokens(TokensEstimator.OPENAI_GPT4) == 4
 
 
 def test_tokens4():

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -49,12 +49,12 @@ def test_estimated_tokens1():
 
 def test_estimated_tokens2():
     response = Response(message="I am fine.")
-    assert response.estimate_tokens(TokensEstimator.OPENAI_GPT35_TURBO) == 4
+    assert response.estimate_tokens(TokensEstimator.OPENAI_GPT_3_5) == 4
 
 
 def test_estimated_tokens3():
     response = Response(message="I am fine.")
-    assert response.estimate_tokens(TokensEstimator.OPENAI_GPT4) == 4
+    assert response.estimate_tokens(TokensEstimator.OPENAI_GPT_4) == 4
 
 
 def test_tokens4():

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -482,4 +482,10 @@ def test_estimated_tokens2():
     prompt = Prompt(message="Hello, how are you?", role=Role.USER)
     response = Response(message="I am fine.")
     session = Session(messages=[prompt, response], title="session")
-    assert session.estimate_tokens(TokensEstimator.OPENAI) == 14
+    assert session.estimate_tokens(TokensEstimator.OPENAI_GPT35_TURBO) == 14
+
+def test_estimated_tokens3():
+    prompt = Prompt(message="Hello, how are you?", role=Role.USER)
+    response = Response(message="I am fine.")
+    session = Session(messages=[prompt, response], title="session")
+    assert session.estimate_tokens(TokensEstimator.OPENAI_GPT4) == 15

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -482,10 +482,10 @@ def test_estimated_tokens2():
     prompt = Prompt(message="Hello, how are you?", role=Role.USER)
     response = Response(message="I am fine.")
     session = Session(messages=[prompt, response], title="session")
-    assert session.estimate_tokens(TokensEstimator.OPENAI_GPT35_TURBO) == 14
+    assert session.estimate_tokens(TokensEstimator.OPENAI_GPT_3_5) == 14
 
 def test_estimated_tokens3():
     prompt = Prompt(message="Hello, how are you?", role=Role.USER)
     response = Response(message="I am fine.")
     session = Session(messages=[prompt, response], title="session")
-    assert session.estimate_tokens(TokensEstimator.OPENAI_GPT4) == 15
+    assert session.estimate_tokens(TokensEstimator.OPENAI_GPT_4) == 15

--- a/tests/test_token_estimators.py
+++ b/tests/test_token_estimators.py
@@ -1,4 +1,4 @@
-from memor.tokens_estimator import openai_tokens_estimator, universal_tokens_estimator
+from memor.tokens_estimator import openai_tokens_estimator_gpt35_turbo, openai_tokens_estimator_gpt4, universal_tokens_estimator
 
 TEST_CASE_NAME = "Token Estimators tests"
 
@@ -61,31 +61,31 @@ def test_universal_tokens_estimator_with_print_statements():
 
 def test_openai_tokens_estimator_with_function_definition():
     message = "def add(a, b): return a + b"
-    assert openai_tokens_estimator(message) == 11
+    assert openai_tokens_estimator_gpt35_turbo(message) == 11
 
 
 def test_openai_tokens_estimator_with_url():
     message = "Visit https://openai.com for more info."
-    assert openai_tokens_estimator(message) == 18
+    assert openai_tokens_estimator_gpt35_turbo(message) == 18
 
 
 def test_openai_tokens_estimator_with_long_words():
     message = "This is a verylongwordwithoutspaces and should be counted properly."
-    assert openai_tokens_estimator(message) == 25
+    assert openai_tokens_estimator_gpt35_turbo(message) == 25
 
 
 def test_openai_tokens_estimator_with_newlines():
     message = "Line1\nLine2\nLine3\n"
-    assert openai_tokens_estimator(message) == 7
+    assert openai_tokens_estimator_gpt35_turbo(message) == 7
 
 
 def test_openai_tokens_estimator_with_non_string_input():
-    assert openai_tokens_estimator(12345) == 0
-    assert openai_tokens_estimator(None) == 0
-    assert openai_tokens_estimator([]) == 0
-    assert openai_tokens_estimator({}) == 0
+    assert openai_tokens_estimator_gpt35_turbo(12345) == 0
+    assert openai_tokens_estimator_gpt35_turbo(None) == 0
+    assert openai_tokens_estimator_gpt35_turbo([]) == 0
+    assert openai_tokens_estimator_gpt35_turbo({}) == 0
 
 
 def test_openai_tokens_estimator_with_gpt4_model():
     message = "This is a test sentence that should be counted properly even with GPT-4. I am making it longer to test the model."
-    assert openai_tokens_estimator(message, model="gpt-4") == 45
+    assert openai_tokens_estimator_gpt4(message) == 45

--- a/tests/test_token_estimators.py
+++ b/tests/test_token_estimators.py
@@ -79,13 +79,6 @@ def test_openai_tokens_estimator_with_newlines():
     assert openai_tokens_estimator_gpt35_turbo(message) == 7
 
 
-def test_openai_tokens_estimator_with_non_string_input():
-    assert openai_tokens_estimator_gpt35_turbo(12345) == 0
-    assert openai_tokens_estimator_gpt35_turbo(None) == 0
-    assert openai_tokens_estimator_gpt35_turbo([]) == 0
-    assert openai_tokens_estimator_gpt35_turbo({}) == 0
-
-
 def test_openai_tokens_estimator_with_gpt4_model():
     message = "This is a test sentence that should be counted properly even with GPT-4. I am making it longer to test the model."
     assert openai_tokens_estimator_gpt4(message) == 45

--- a/tests/test_token_estimators.py
+++ b/tests/test_token_estimators.py
@@ -1,4 +1,4 @@
-from memor.tokens_estimator import openai_tokens_estimator_gpt35_turbo, openai_tokens_estimator_gpt4, universal_tokens_estimator
+from memor.tokens_estimator import openai_tokens_estimator_gpt_3_5, openai_tokens_estimator_gpt_4, universal_tokens_estimator
 
 TEST_CASE_NAME = "Token Estimators tests"
 
@@ -61,24 +61,24 @@ def test_universal_tokens_estimator_with_print_statements():
 
 def test_openai_tokens_estimator_with_function_definition():
     message = "def add(a, b): return a + b"
-    assert openai_tokens_estimator_gpt35_turbo(message) == 11
+    assert openai_tokens_estimator_gpt_3_5(message) == 11
 
 
 def test_openai_tokens_estimator_with_url():
     message = "Visit https://openai.com for more info."
-    assert openai_tokens_estimator_gpt35_turbo(message) == 18
+    assert openai_tokens_estimator_gpt_3_5(message) == 18
 
 
 def test_openai_tokens_estimator_with_long_words():
     message = "This is a verylongwordwithoutspaces and should be counted properly."
-    assert openai_tokens_estimator_gpt35_turbo(message) == 25
+    assert openai_tokens_estimator_gpt_3_5(message) == 25
 
 
 def test_openai_tokens_estimator_with_newlines():
     message = "Line1\nLine2\nLine3\n"
-    assert openai_tokens_estimator_gpt35_turbo(message) == 7
+    assert openai_tokens_estimator_gpt_3_5(message) == 7
 
 
 def test_openai_tokens_estimator_with_gpt4_model():
     message = "This is a test sentence that should be counted properly even with GPT-4. I am making it longer to test the model."
-    assert openai_tokens_estimator_gpt4(message) == 45
+    assert openai_tokens_estimator_gpt_4(message) == 45


### PR DESCRIPTION
#### Reference Issues/PRs
#67 

#### What does this implement/fix? Explain your changes.
We separated the token estimators for two models of ChatGPT3.5-turbo and 4.
Now we have

- `openai_tokens_estimator_gpt_3_5`
- `openai_tokens_estimator_gpt_4`

as our estimators instead of `openai_tokens_estimator`.

#### Any other comments?
@sepandhaghighi Note that I removed the check for non-str inputs since we're not doing it for the universal estimator, and I wanted them to be more consistent. If we needed them we can add them in a future PR.
