### PR TITLE
Null Safety Issue Fixed in Memor Validation

### DIFF
--- a/memor/prompt.py
+++ b/memor/prompt.py
@@ -298,8 +298,7 @@ class Prompt:
         except Exception:
             raise MemorValidationError(INVALID_PROMPT_STRUCTURE_MESSAGE)
         _validate_string(result["message"], "message")
-        if result["tokens"]:
-            _validate_pos_int(result["tokens"], "tokens")
+        if result["tokens"] is not None: _validate_pos_int(result["tokens"], "tokens")
         _validate_message_id(result["id"])
         _validate_string(result["memor_version"], "memor_version")
         _validate_pos_int(result["selected_response_index"], "selected_response_index")

--- a/memor/response.py
+++ b/memor/response.py
@@ -239,8 +239,8 @@ class Response:
             else:
                 loaded_obj = json_object.copy()
             result["message"] = loaded_obj["message"]
-            result["score"] = loaded_obj.get("score", None)
-            result["temperature"] = loaded_obj.get("temperature", None)
+            result["score"] = loaded_obj["score"]
+            result["temperature"] = loaded_obj["temperature"]
             result["tokens"] = loaded_obj.get("tokens", None)
             result["inference_time"] = loaded_obj.get("inference_time", None)
             result["model"] = loaded_obj["model"]

--- a/memor/response.py
+++ b/memor/response.py
@@ -239,8 +239,8 @@ class Response:
             else:
                 loaded_obj = json_object.copy()
             result["message"] = loaded_obj["message"]
-            result["score"] = loaded_obj["score"]
-            result["temperature"] = loaded_obj["temperature"]
+            result["score"] = loaded_obj.get("score", None)
+            result["temperature"] = loaded_obj.get("temperature", None)
             result["tokens"] = loaded_obj.get("tokens", None)
             result["inference_time"] = loaded_obj.get("inference_time", None)
             result["model"] = loaded_obj["model"]
@@ -252,14 +252,10 @@ class Response:
         except Exception:
             raise MemorValidationError(INVALID_RESPONSE_STRUCTURE_MESSAGE)
         _validate_string(result["message"], "message")
-        if result["score"]:
-            _validate_probability(result["score"], "score")
-        if result["temperature"]:
-            _validate_pos_float(result["temperature"], "temperature")
-        if result["tokens"]:
-            _validate_pos_int(result["tokens"], "tokens")
-        if result["inference_time"]:
-            _validate_pos_float(result["inference_time"], "inference_time")
+        if result["score"] is not None: _validate_probability(result["score"], "score")
+        if result["temperature"] is not None: _validate_pos_float(result["temperature"], "temperature")
+        if result["tokens"] is not None: _validate_pos_int(result["tokens"], "tokens")
+        if result["inference_time"] is not None: _validate_pos_float(result["inference_time"], "inference_time")
         _validate_string(result["model"], "model")
         _validate_message_id(result["id"])
         _validate_string(result["memor_version"], "memor_version")

--- a/memor/session.py
+++ b/memor/session.py
@@ -367,7 +367,7 @@ class Session:
                 loaded_obj = json.loads(json_object)
             else:
                 loaded_obj = json_object.copy()
-            result["title"] = loaded_obj.get("title", None)
+            result["title"] = loaded_obj["title"]
             result["render_counter"] = loaded_obj.get("render_counter", 0)
             result["messages_status"] = loaded_obj["messages_status"]
             result["messages"] = []

--- a/memor/session.py
+++ b/memor/session.py
@@ -367,7 +367,7 @@ class Session:
                 loaded_obj = json.loads(json_object)
             else:
                 loaded_obj = json_object.copy()
-            result["title"] = loaded_obj["title"]
+            result["title"] = loaded_obj.get("title", None)
             result["render_counter"] = loaded_obj.get("render_counter", 0)
             result["messages_status"] = loaded_obj["messages_status"]
             result["messages"] = []
@@ -383,7 +383,7 @@ class Session:
             result["date_modified"] = datetime.datetime.strptime(loaded_obj["date_modified"], DATE_TIME_FORMAT)
         except Exception:
             raise MemorValidationError(INVALID_SESSION_STRUCTURE_MESSAGE)
-        _validate_string(result["title"], "title")
+        if result["title"] is not None: _validate_string(result["title"], "title")
         _validate_pos_int(result["render_counter"], "render_counter")
         _validate_status(result["messages_status"], result["messages"])
         _validate_string(result["memor_version"], "memor_version")

--- a/memor/template.py
+++ b/memor/template.py
@@ -162,10 +162,9 @@ class PromptTemplate:
             result["date_modified"] = datetime.datetime.strptime(loaded_obj["date_modified"], DATE_TIME_FORMAT)
         except Exception:
             raise MemorValidationError(INVALID_TEMPLATE_STRUCTURE_MESSAGE)
-        _validate_string(result["content"], "content")
-        if result["title"]:
-            _validate_string(result["title"], "title")
-        _validate_custom_map(result["custom_map"])
+        if result["content"] is not None: _validate_string(result["content"], "content")
+        if result["title"] is not None: _validate_string(result["title"], "title")
+        if result["custom_map"] is not None: _validate_custom_map(result["custom_map"])
         _validate_string(result["memor_version"], "memor_version")
         return result
 

--- a/memor/template.py
+++ b/memor/template.py
@@ -154,9 +154,9 @@ class PromptTemplate:
                 loaded_obj = json.loads(json_object)
             else:
                 loaded_obj = json_object.copy()
-            result["content"] = loaded_obj["content"]
-            result["title"] = loaded_obj["title"]
-            result["custom_map"] = loaded_obj["custom_map"]
+            result["content"] = loaded_obj.get("content", None)
+            result["title"] = loaded_obj.get("title", None)
+            result["custom_map"] = loaded_obj.get("custom_map", None)
             result["memor_version"] = loaded_obj["memor_version"]
             result["date_created"] = datetime.datetime.strptime(loaded_obj["date_created"], DATE_TIME_FORMAT)
             result["date_modified"] = datetime.datetime.strptime(loaded_obj["date_modified"], DATE_TIME_FORMAT)

--- a/memor/template.py
+++ b/memor/template.py
@@ -154,9 +154,9 @@ class PromptTemplate:
                 loaded_obj = json.loads(json_object)
             else:
                 loaded_obj = json_object.copy()
-            result["content"] = loaded_obj.get("content", None)
-            result["title"] = loaded_obj.get("title", None)
-            result["custom_map"] = loaded_obj.get("custom_map", None)
+            result["content"] = loaded_obj["content"]
+            result["title"] = loaded_obj["title"]
+            result["custom_map"] = loaded_obj["custom_map"]
             result["memor_version"] = loaded_obj["memor_version"]
             result["date_created"] = datetime.datetime.strptime(loaded_obj["date_created"], DATE_TIME_FORMAT)
             result["date_modified"] = datetime.datetime.strptime(loaded_obj["date_modified"], DATE_TIME_FORMAT)

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -299,7 +299,7 @@ def test_json2():
 def test_json3():
     prompt = Prompt()
     with pytest.raises(MemorValidationError, match=r"Invalid prompt structure. It should be a JSON object with proper fields."):
-        # an corrupted JSON string without `responses` field
+        # a corrupted JSON string without `responses` field
         prompt.from_json(r"""{
                          "type": "Prompt",
                          "message": "Hello, how are you?",
@@ -324,7 +324,7 @@ def test_json3():
 def test_json4():
     prompt = Prompt()
     with pytest.raises(MemorValidationError, match=r"Invalid value. `tokens` must be a positive integer."):
-        # an corrupted JSON string with invalid `tokens` field
+        # a corrupted JSON string with invalid `tokens` field
         prompt.from_json(r"""{
                          "type": "Prompt",
                          "message": "Hello, how are you?",

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -330,11 +330,16 @@ def test_json4():
                          "message": "Hello, how are you?",
                          "selected_response_index": 0,
                          "tokens": "invalid",
-                        "responses": [
+                         "responses": [
                             {
+                                "type": "Response",
                                 "message": "I am fine.",
-                                "model": "gpt-4",
                                 "role": "user",
+                                "model": "gpt-4",
+                                "id": "c249fb19-2265-4369-8d35-16f060d3ef34",
+                                "memor_version": "0.6",
+                                "date_created": "2025-05-21 07:20:44 +0000",
+                                "date_modified": "2025-05-21 07:20:44 +0000"
                             }],
                          "role": "assistant",
                          "id": "b0bb6573-57eb-48c3-8c35-63f8e71dd30c",

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -334,12 +334,16 @@ def test_json4():
                             {
                                 "type": "Response",
                                 "message": "I am fine.",
+                                "score": 0.8,
+                                "temperature": 0.5,
+                                "tokens": null,
+                                "inference_time": null,
                                 "role": "user",
                                 "model": "gpt-4",
-                                "id": "c249fb19-2265-4369-8d35-16f060d3ef34",
+                                "id": "8eb35f46-b660-4e28-92df-487211f7357e",
                                 "memor_version": "0.6",
-                                "date_created": "2025-05-21 07:20:44 +0000",
-                                "date_modified": "2025-05-21 07:20:44 +0000"
+                                "date_created": "2025-05-21 17:21:21 +0000",
+                                "date_modified": "2025-05-21 17:21:21 +0000"
                             }],
                          "role": "assistant",
                          "id": "b0bb6573-57eb-48c3-8c35-63f8e71dd30c",

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -321,6 +321,38 @@ def test_json3():
     assert prompt.role == Role.USER
 
 
+def test_json4():
+    prompt = Prompt()
+    with pytest.raises(MemorValidationError, match=r"Invalid value. `tokens` must be a positive integer."):
+        # an corrupted JSON string with invalid `tokens` field
+        prompt.from_json(r"""{
+                         "type": "Prompt",
+                         "message": "Hello, how are you?",
+                         "selected_response_index": 0,
+                         "tokens": "invalid",
+                        "responses": [
+                            {
+                                "message": "I am fine.",
+                                "model": "gpt-4",
+                                "role": "user",
+                            }],
+                         "role": "assistant",
+                         "id": "b0bb6573-57eb-48c3-8c35-63f8e71dd30c",
+                         "template": {
+                            "title": "Basic/Prompt-Response Standard",
+                            "content": "{instruction}Prompt: {prompt[message]}\nResponse: {response[message]}",
+                            "memor_version": "0.6", "custom_map": {"instruction": ""},
+                            "date_created": "2025-05-07 21:49:23 +0000",
+                            "date_modified": "2025-05-07 21:49:23 +0000"},
+                         "memor_version": "0.6",
+                         "date_created": "2025-05-07 21:49:23 +0000",
+                         "date_modified": "2025-05-07 21:49:23 +0000"}""")
+    assert prompt.message == ''
+    assert prompt.responses == []
+    assert prompt.role == Role.USER
+    assert prompt.tokens is None
+
+
 def test_save1():
     message = "Hello, how are you?"
     response1 = Response(message="I am fine.", model=LLMModel.GPT_4, temperature=0.5, role=Role.USER, score=0.8)

--- a/tests/test_prompt_template.py
+++ b/tests/test_prompt_template.py
@@ -125,16 +125,69 @@ def test_json1():
 def test_json2():
     template = PromptTemplate()
     with pytest.raises(MemorValidationError, match=r"Invalid template structure. It should be a JSON object with proper fields."):
-        # an corrupted JSON string without `content` field
+        # an corrupted JSON string corrupted `content` field
         template.from_json(r"""{
-                           "title": "template1",
-                           "memor_version": "0.6",
-                           "custom_map": {"language": "Python"},
-                           "date_created": "2025-05-07 21:52:33 +0000",
-                           "date_modified": "2025-05-07 21:52:33 +0000"}""")
+                            "content": invalid,
+                            "title": "template1",
+                            "memor_version": "0.6",
+                            "custom_map": {"language": "Python"},
+                            "date_created": "2025-05-07 21:52:33 +0000",
+                            "date_modified": "2025-05-07 21:52:33 +0000"}""")
     assert template.content is None
     assert template.custom_map is None
     assert template.title is None
+
+
+def test_json3():
+    template = PromptTemplate()
+    with pytest.raises(MemorValidationError, match=r"Invalid value. `content` must be a string."):
+        # an corrupted JSON string with wrong `content` field
+        template.from_json(r"""{
+                            "content": 0,
+                            "title": "template1",
+                            "memor_version": "0.6",
+                            "custom_map": {"language": "Python"},
+                            "date_created": "2025-05-07 21:52:33 +0000",
+                            "date_modified": "2025-05-07 21:52:33 +0000"}""")
+    assert template.content is None
+    assert template.custom_map is None
+    assert template.title is None
+    with pytest.raises(MemorValidationError, match=r"Invalid value. `title` must be a string."):
+        # an corrupted JSON string with wrong `title` field
+        template.from_json(r"""{
+                            "title": 0,
+                            "content": "Act as a {language} developer and respond to this question:\n{prompt_message}",
+                            "memor_version": "0.6",
+                            "custom_map": {"language": "Python"},
+                            "date_created": "2025-05-07 21:52:33 +0000",
+                            "date_modified": "2025-05-07 21:52:33 +0000"}""")
+    assert template.content == None
+    assert template.custom_map == None
+    assert template.title == None
+    with pytest.raises(MemorValidationError, match=r"Invalid custom map: it must be a dictionary with keys and values that can be converted to strings."):
+        # an corrupted JSON string with wrong `custom_map` field
+        template.from_json(r"""{
+                            "title": "template1",
+                            "content": "Act as a {language} developer and respond to this question:\n{prompt_message}",
+                            "memor_version": "0.6",
+                            "custom_map": 0,
+                            "date_created": "2025-05-07 21:52:33 +0000",
+                            "date_modified": "2025-05-07 21:52:33 +0000"}""")
+    assert template.content == None
+    assert template.custom_map == None
+    assert template.title == None
+    with pytest.raises(MemorValidationError, match=r"Invalid value. `memor_version` must be a string."):
+        # an corrupted JSON string with wrong `memor_version` field
+        template.from_json(r"""{
+                            "title": "template1",
+                            "content": "Act as a {language} developer and respond to this question:\n{prompt_message}",
+                            "memor_version": 0.6,
+                            "custom_map": {"language": "Python"},
+                            "date_created": "2025-05-07 21:52:33 +0000",
+                            "date_modified": "2025-05-07 21:52:33 +0000"}""")
+    assert template.content == None
+    assert template.custom_map == None
+    assert template.title == None
 
 
 def test_save1():

--- a/tests/test_prompt_template.py
+++ b/tests/test_prompt_template.py
@@ -152,6 +152,10 @@ def test_json3():
     assert template.content is None
     assert template.custom_map is None
     assert template.title is None
+
+
+def test_json4():
+    template = PromptTemplate()
     with pytest.raises(MemorValidationError, match=r"Invalid value. `title` must be a string."):
         # a corrupted JSON string with wrong `title` field
         template.from_json(r"""{
@@ -164,6 +168,10 @@ def test_json3():
     assert template.content is None
     assert template.custom_map is None
     assert template.title is None
+
+
+def test_json5():
+    template = PromptTemplate()
     with pytest.raises(MemorValidationError, match=r"Invalid custom map: it must be a dictionary with keys and values that can be converted to strings."):
         # a corrupted JSON string with wrong `custom_map` field
         template.from_json(r"""{
@@ -176,6 +184,10 @@ def test_json3():
     assert template.content is None
     assert template.custom_map is None
     assert template.title is None
+
+
+def test_json6():
+    template = PromptTemplate()
     with pytest.raises(MemorValidationError, match=r"Invalid value. `memor_version` must be a string."):
         # a corrupted JSON string with wrong `memor_version` field
         template.from_json(r"""{

--- a/tests/test_prompt_template.py
+++ b/tests/test_prompt_template.py
@@ -125,7 +125,7 @@ def test_json1():
 def test_json2():
     template = PromptTemplate()
     with pytest.raises(MemorValidationError, match=r"Invalid template structure. It should be a JSON object with proper fields."):
-        # an corrupted JSON string corrupted `content` field
+        # a corrupted JSON string with an invalid `content` field
         template.from_json(r"""{
                             "content": invalid,
                             "title": "template1",
@@ -141,7 +141,7 @@ def test_json2():
 def test_json3():
     template = PromptTemplate()
     with pytest.raises(MemorValidationError, match=r"Invalid value. `content` must be a string."):
-        # an corrupted JSON string with wrong `content` field
+        # a corrupted JSON string with wrong `content` field
         template.from_json(r"""{
                             "content": 0,
                             "title": "template1",
@@ -153,7 +153,7 @@ def test_json3():
     assert template.custom_map is None
     assert template.title is None
     with pytest.raises(MemorValidationError, match=r"Invalid value. `title` must be a string."):
-        # an corrupted JSON string with wrong `title` field
+        # a corrupted JSON string with wrong `title` field
         template.from_json(r"""{
                             "title": 0,
                             "content": "Act as a {language} developer and respond to this question:\n{prompt_message}",
@@ -161,11 +161,11 @@ def test_json3():
                             "custom_map": {"language": "Python"},
                             "date_created": "2025-05-07 21:52:33 +0000",
                             "date_modified": "2025-05-07 21:52:33 +0000"}""")
-    assert template.content == None
-    assert template.custom_map == None
-    assert template.title == None
+    assert template.content is None
+    assert template.custom_map is None
+    assert template.title is None
     with pytest.raises(MemorValidationError, match=r"Invalid custom map: it must be a dictionary with keys and values that can be converted to strings."):
-        # an corrupted JSON string with wrong `custom_map` field
+        # a corrupted JSON string with wrong `custom_map` field
         template.from_json(r"""{
                             "title": "template1",
                             "content": "Act as a {language} developer and respond to this question:\n{prompt_message}",
@@ -173,11 +173,11 @@ def test_json3():
                             "custom_map": 0,
                             "date_created": "2025-05-07 21:52:33 +0000",
                             "date_modified": "2025-05-07 21:52:33 +0000"}""")
-    assert template.content == None
-    assert template.custom_map == None
-    assert template.title == None
+    assert template.content is None
+    assert template.custom_map is None
+    assert template.title is None
     with pytest.raises(MemorValidationError, match=r"Invalid value. `memor_version` must be a string."):
-        # an corrupted JSON string with wrong `memor_version` field
+        # a corrupted JSON string with wrong `memor_version` field
         template.from_json(r"""{
                             "title": "template1",
                             "content": "Act as a {language} developer and respond to this question:\n{prompt_message}",
@@ -185,9 +185,9 @@ def test_json3():
                             "custom_map": {"language": "Python"},
                             "date_created": "2025-05-07 21:52:33 +0000",
                             "date_modified": "2025-05-07 21:52:33 +0000"}""")
-    assert template.content == None
-    assert template.custom_map == None
-    assert template.title == None
+    assert template.content is None
+    assert template.custom_map is None
+    assert template.title is None
 
 
 def test_save1():

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -240,77 +240,44 @@ def test_json3():
                            "message": "I am fine.",
                            "type": "Response",
                            "score": "invalid",
-                           "temperature": 0.5,
-                           "tokens": null,
-                           "inference_time": null,
-                           "role": "user",
-                           "model": "gpt-4",
                            "id": "7dfce0e0-53bc-4500-bf79-7c9cd705087c",
                            "memor_version": "0.6",
                            "date_created": "2025-05-07 21:54:48 +0000",
                            "date_modified": "2025-05-07 21:54:48 +0000"}""")
-    assert response.message == ''
-    assert response.model == 'unknown'
-    assert response.temperature is None
-    assert response.role == Role.ASSISTANT
-    assert response.score is None
-    assert response.inference_time is None
-    assert response.tokens is None
+    assert response.message == '' and response.model == 'unknown' and response.temperature is None
+    assert response.role == Role.ASSISTANT and response.score is None and response.inference_time is None
     with pytest.raises(MemorValidationError, match="Invalid value. `temperature` must be a positive float."):
         response.from_json(r"""{
                            "message": "I am fine.",
                            "type": "Response",
-                           "score": 0.8,
                            "temperature": -0.5,
-                           "tokens": null,
-                           "inference_time": null,
-                           "role": "user",
-                           "model": "gpt-4",
                            "id": "7dfce0e0-53bc-4500-bf79-7c9cd705087c",
                            "memor_version": "0.6",
                            "date_created": "2025-05-07 21:54:48 +0000",
                            "date_modified": "2025-05-07 21:54:48 +0000"}""")
-    assert response.message == ''
-    assert response.model == 'unknown'
-    assert response.temperature is None
+    assert response.message == '' and response.model == 'unknown' and response.temperature is None
     with pytest.raises(MemorValidationError, match="Invalid value. `tokens` must be a positive int."):
         response.from_json(r"""{
                            "message": "I am fine.",
                            "type": "Response",
-                           "score": 0.8,
-                           "temperature": 0.5,
                            "tokens": -1,
-                           "inference_time": null,
-                           "role": "user",
-                           "model": "gpt-4",
                            "id": "7dfce0e0-53bc-4500-bf79-7c9cd705087c",
                            "memor_version": "0.6",
                            "date_created": "2025-05-07 21:54:48 +0000",
                            "date_modified": "2025-05-07 21:54:48 +0000"}""")
-    assert response.message == ''
-    assert response.model == 'unknown'
-    assert response.temperature is None
+    assert response.message == '' and response.model == 'unknown' and response.temperature is None
     assert response.tokens is None
     with pytest.raises(MemorValidationError, match="Invalid value. `inference_time` must be a positive float."):
         response.from_json(r"""{
                            "message": "I am fine.",
                            "type": "Response",
-                           "score": 0.8,
-                           "temperature": 0.5,
-                           "tokens": null,
                            "inference_time": -1,
-                           "role": "user",
-                           "model": "gpt-4",
                            "id": "7dfce0e0-53bc-4500-bf79-7c9cd705087c",
                            "memor_version": "0.6",
                            "date_created": "2025-05-07 21:54:48 +0000",
                            "date_modified": "2025-05-07 21:54:48 +0000"}""")
-    assert response.message == ''
-    assert response.model == 'unknown'
-    assert response.temperature is None
-    assert response.tokens is None
-    assert response.inference_time is None
-
+    assert response.message == '' and response.model == 'unknown' and response.temperature is None
+    assert response.tokens is None and response.inference_time is None
 
 
 def test_save1():

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -210,7 +210,7 @@ def test_json1():
 def test_json2():
     response = Response()
     with pytest.raises(MemorValidationError, match=r"Invalid response structure. It should be a JSON object with proper fields."):
-        # an corrupted JSON string without `message` field
+        # a corrupted JSON string without `message` field
         response.from_json(r"""{
                            "type": "Response",
                            "score": 0.8,
@@ -235,7 +235,7 @@ def test_json2():
 def test_json3():
     response = Response()
     with pytest.raises(MemorValidationError, match=r"Invalid value. `score` must be a value between 0 and 1."):
-        # an corrupted JSON string with invalid `score` field
+        # a corrupted JSON string with invalid `score` field
         response.from_json(r"""{
                            "message": "I am fine.",
                            "type": "Response",

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -232,6 +232,87 @@ def test_json2():
     assert response.tokens is None
 
 
+def test_json3():
+    response = Response()
+    with pytest.raises(MemorValidationError, match=r"Invalid value. `score` must be a value between 0 and 1."):
+        # an corrupted JSON string with invalid `score` field
+        response.from_json(r"""{
+                           "message": "I am fine.",
+                           "type": "Response",
+                           "score": "invalid",
+                           "temperature": 0.5,
+                           "tokens": null,
+                           "inference_time": null,
+                           "role": "user",
+                           "model": "gpt-4",
+                           "id": "7dfce0e0-53bc-4500-bf79-7c9cd705087c",
+                           "memor_version": "0.6",
+                           "date_created": "2025-05-07 21:54:48 +0000",
+                           "date_modified": "2025-05-07 21:54:48 +0000"}""")
+    assert response.message == ''
+    assert response.model == 'unknown'
+    assert response.temperature is None
+    assert response.role == Role.ASSISTANT
+    assert response.score is None
+    assert response.inference_time is None
+    assert response.tokens is None
+    with pytest.raises(MemorValidationError, match="Invalid value. `temperature` must be a positive float."):
+        response.from_json(r"""{
+                           "message": "I am fine.",
+                           "type": "Response",
+                           "score": 0.8,
+                           "temperature": -0.5,
+                           "tokens": null,
+                           "inference_time": null,
+                           "role": "user",
+                           "model": "gpt-4",
+                           "id": "7dfce0e0-53bc-4500-bf79-7c9cd705087c",
+                           "memor_version": "0.6",
+                           "date_created": "2025-05-07 21:54:48 +0000",
+                           "date_modified": "2025-05-07 21:54:48 +0000"}""")
+    assert response.message == ''
+    assert response.model == 'unknown'
+    assert response.temperature is None
+    with pytest.raises(MemorValidationError, match="Invalid value. `tokens` must be a positive int."):
+        response.from_json(r"""{
+                           "message": "I am fine.",
+                           "type": "Response",
+                           "score": 0.8,
+                           "temperature": 0.5,
+                           "tokens": -1,
+                           "inference_time": null,
+                           "role": "user",
+                           "model": "gpt-4",
+                           "id": "7dfce0e0-53bc-4500-bf79-7c9cd705087c",
+                           "memor_version": "0.6",
+                           "date_created": "2025-05-07 21:54:48 +0000",
+                           "date_modified": "2025-05-07 21:54:48 +0000"}""")
+    assert response.message == ''
+    assert response.model == 'unknown'
+    assert response.temperature is None
+    assert response.tokens is None
+    with pytest.raises(MemorValidationError, match="Invalid value. `inference_time` must be a positive float."):
+        response.from_json(r"""{
+                           "message": "I am fine.",
+                           "type": "Response",
+                           "score": 0.8,
+                           "temperature": 0.5,
+                           "tokens": null,
+                           "inference_time": -1,
+                           "role": "user",
+                           "model": "gpt-4",
+                           "id": "7dfce0e0-53bc-4500-bf79-7c9cd705087c",
+                           "memor_version": "0.6",
+                           "date_created": "2025-05-07 21:54:48 +0000",
+                           "date_modified": "2025-05-07 21:54:48 +0000"}""")
+    assert response.message == ''
+    assert response.model == 'unknown'
+    assert response.temperature is None
+    assert response.tokens is None
+    assert response.inference_time is None
+
+
+
 def test_save1():
     response = Response(message="I am fine.", model=LLMModel.GPT_4, temperature=0.5, role=Role.USER, score=0.8)
     result = response.save("response_test1.json")

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -210,7 +210,7 @@ def test_json1():
 def test_json2():
     response = Response()
     with pytest.raises(MemorValidationError, match=r"Invalid response structure. It should be a JSON object with proper fields."):
-        # a corrupted JSON string without `message` field
+        # an corrupted JSON string without `message` field
         response.from_json(r"""{
                            "type": "Response",
                            "score": 0.8,
@@ -235,49 +235,93 @@ def test_json2():
 def test_json3():
     response = Response()
     with pytest.raises(MemorValidationError, match=r"Invalid value. `score` must be a value between 0 and 1."):
-        # a corrupted JSON string with invalid `score` field
+        # an corrupted JSON string with invalid `score` field
         response.from_json(r"""{
                            "message": "I am fine.",
                            "type": "Response",
                            "score": "invalid",
+                           "temperature": 0.5,
+                           "tokens": null,
+                           "inference_time": null,
+                           "role": "user",
+                           "model": "gpt-4",
                            "id": "7dfce0e0-53bc-4500-bf79-7c9cd705087c",
                            "memor_version": "0.6",
                            "date_created": "2025-05-07 21:54:48 +0000",
                            "date_modified": "2025-05-07 21:54:48 +0000"}""")
-    assert response.message == '' and response.model == 'unknown' and response.temperature is None
-    assert response.role == Role.ASSISTANT and response.score is None and response.inference_time is None
+    assert response.message == ''
+    assert response.model == 'unknown'
+    assert response.temperature is None
+    assert response.role == Role.ASSISTANT
+    assert response.score is None
+    assert response.inference_time is None
+    assert response.tokens is None
+
+
+def test_json4():
+    response = Response()
     with pytest.raises(MemorValidationError, match="Invalid value. `temperature` must be a positive float."):
         response.from_json(r"""{
                            "message": "I am fine.",
                            "type": "Response",
+                           "score": 0.8,
                            "temperature": -0.5,
+                           "tokens": null,
+                           "inference_time": null,
+                           "role": "user",
+                           "model": "gpt-4",
                            "id": "7dfce0e0-53bc-4500-bf79-7c9cd705087c",
                            "memor_version": "0.6",
                            "date_created": "2025-05-07 21:54:48 +0000",
                            "date_modified": "2025-05-07 21:54:48 +0000"}""")
-    assert response.message == '' and response.model == 'unknown' and response.temperature is None
+    assert response.message == ''
+    assert response.model == 'unknown'
+    assert response.temperature is None
+
+
+def test_json5():
+    response = Response()
     with pytest.raises(MemorValidationError, match="Invalid value. `tokens` must be a positive int."):
         response.from_json(r"""{
                            "message": "I am fine.",
                            "type": "Response",
+                           "score": 0.8,
+                           "temperature": 0.5,
                            "tokens": -1,
+                           "inference_time": null,
+                           "role": "user",
+                           "model": "gpt-4",
                            "id": "7dfce0e0-53bc-4500-bf79-7c9cd705087c",
                            "memor_version": "0.6",
                            "date_created": "2025-05-07 21:54:48 +0000",
                            "date_modified": "2025-05-07 21:54:48 +0000"}""")
-    assert response.message == '' and response.model == 'unknown' and response.temperature is None
+    assert response.message == ''
+    assert response.model == 'unknown'
+    assert response.temperature is None
     assert response.tokens is None
+
+
+def test_json6():
+    response = Response()
     with pytest.raises(MemorValidationError, match="Invalid value. `inference_time` must be a positive float."):
         response.from_json(r"""{
                            "message": "I am fine.",
                            "type": "Response",
+                           "score": 0.8,
+                           "temperature": 0.5,
+                           "tokens": null,
                            "inference_time": -1,
+                           "role": "user",
+                           "model": "gpt-4",
                            "id": "7dfce0e0-53bc-4500-bf79-7c9cd705087c",
                            "memor_version": "0.6",
                            "date_created": "2025-05-07 21:54:48 +0000",
                            "date_modified": "2025-05-07 21:54:48 +0000"}""")
-    assert response.message == '' and response.model == 'unknown' and response.temperature is None
-    assert response.tokens is None and response.inference_time is None
+    assert response.message == ''
+    assert response.model == 'unknown'
+    assert response.temperature is None
+    assert response.tokens is None
+    assert response.inference_time is None
 
 
 def test_save1():

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -293,7 +293,7 @@ def test_load2():
 def test_load3():
     session = Session()
     with pytest.raises(MemorValidationError, match=r"Invalid session structure. It should be a JSON object with proper fields."):
-        # an corrupted JSON string without `messages_status` field
+        # a corrupted JSON string without `messages_status` field
         session.from_json(r"""{
                           "type": "Session",
                           "title": "session1",
@@ -342,7 +342,7 @@ def test_load3():
 def test_load4():
     session = Session()
     with pytest.raises(MemorValidationError, match=r"Invalid value. `title` must be a string."):
-        # an corrupted JSON string with invalid `title` field
+        # a corrupted JSON string with invalid `title` field
         session.from_json(r"""{
                           "type": "Session",
                           "title": 0,

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -339,6 +339,56 @@ def test_load3():
     assert session.messages_status == []
 
 
+def test_load4():
+    session = Session()
+    with pytest.raises(MemorValidationError, match=r"Invalid value. `title` must be a string."):
+        # an corrupted JSON string with invalid `title` field
+        session.from_json(r"""{
+                          "type": "Session",
+                          "title": 0,
+                          "render_counter": 1,
+                          "messages_status": [true, false],
+                          "messages": [
+                          {
+                            "type": "Prompt",
+                            "message": "Hello, how are you?",
+                            "responses": [],
+                            "selected_response_index": 0,
+                            "tokens": null,
+                            "role": "user",
+                            "id":"465a5bc3-2ede-46b5-af47-294637e44407",
+                            "template": {
+                                "title": "Basic/Prompt",
+                                "content": "{instruction}{prompt[message]}",
+                                "memor_version": "0.6",
+                                "custom_map": {"instruction": ""},
+                                "date_created": "2025-05-07 21:57:05 +0000",
+                                "date_modified": "2025-05-07 21:57:05 +0000"},
+                            "memor_version": "0.6",
+                            "date_created": "2025-05-07 21:57:05 +0000",
+                            "date_modified": "2025-05-07 21:57:05 +0000"},
+                          {
+                            "type": "Response",
+                            "message": "I am fine.",
+                            "score": null,
+                            "temperature": null,
+                            "tokens": null,
+                            "inference_time": null,
+                            "role": "assistant",
+                            "model": "unknown",
+                            "id": "8a2a32b8-d828-4309-9583-2185fba9e3bb",
+                            "memor_version": "0.6",
+                            "date_created": "2025-05-07 21:57:05 +0000",
+                            "date_modified": "2025-05-07 21:57:05 +0000"
+                          }],
+                          "memor_version": "0.6",
+                          "date_created": "2025-05-07 21:57:05 +0000",
+                          "date_modified": "2025-05-07 21:57:05 +0000"}""")
+    assert session.messages == [] and session.title is None
+    assert session.render_counter == 0
+    assert session.messages_status == []
+
+
 def test_render1():
     prompt = Prompt(message="Hello, how are you?", role=Role.USER)
     response = Response(message="I am fine.")


### PR DESCRIPTION
#### Reference Issues/PRs
#116 
#### What does this implement/fix? Explain your changes.
#117 and #120 proposed a null safety bug in which loading memor objects with field that could be `None` (and `null` in the json further on) resulted into the object not loading. This even led to memor not being able to load object which memor itself has saved it. This PR fixes the issue related to that bug.
#### Any other comments?

