### PR TITLE
Memor Usage Examples (Simple Chat + Multi-LLM Chat)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Response` class `size` attribute
 - `Prompt` class `size` attribute
 - `PromptTemplate` class `size` attribute
+- `examples/` directory
 ### Changed
 - Validation bug fixed in `update_messages` method in `Session` class
 - Validation bug fixed in `from_json` method in `PromptTemplate`, `Response`, `Prompt`, and `Session` classes
 - `AI_STUDIO` render format modified
 - `Session` class messages status bug fixed
 - Test system modified
+- `README.md` updated
 ## [0.6] - 2025-05-05
 ### Added
 - `Response` class `id` property

--- a/README.md
+++ b/README.md
@@ -161,7 +161,8 @@ Hi, How are you?
 By using this dynamic structure, you can create flexible and sophisticated prompt templates with Memor. You can design specific schemas for your conversational or instructional formats when interacting with LLM.
 
 #### Examples
-You can check out some provided examples of using Memor in real-life scearios in [examples/README.md](https://github.com/openscilab/memor/blob/master/examples/README.md).
+You can explore real-world usage of Memor in the [`examples/`](examples/README.md) directory.
+This directory includes concise and practical python scripts that demonstrate key features of Memor library.
 
 ## Issues & bug reports
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ Hi, How are you?
 
 By using this dynamic structure, you can create flexible and sophisticated prompt templates with Memor. You can design specific schemas for your conversational or instructional formats when interacting with LLM.
 
+#### Examples
+You can check out some provided examples of using Memor in real-life scearios in [examples/README.md](https://github.com/openscilab/memor/blob/master/examples/README.md).
+
 ## Issues & bug reports
 
 Just fill an issue and describe it. We'll check it ASAP! or send an email to [memor@openscilab.com](mailto:memor@openscilab.com "memor@openscilab.com"). 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,13 @@
 # Memor Examples
-This ...
+This repository contains examples demonstrating how to use the Memor library with various LLMs.
 
-You should install the packages in the `requirements.txt` first.
+You should install the packages in the `requirements.txt` first by running `pip install -r requirements.txt`.
+Following we provide a short description for each example.
 
 ## Simple Chat (`simple_chat.py`)
+A basic interactive chat loop using Memor to manage and render chat history.
+Since single API calls don’t retain conversation history, you'd originally need to manually save your prior chat history in a array.
+Memor simplifies this by providing `Session`, `Prompt`, and `Response` as an intuitive structure for multi-turn interactions.
+
+## Multi-LLM Chat (`multi-llm_chat.py`)
 ...

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,7 @@
+# Memor Examples
+This ...
+
+You should install the packages in the `requirements.txt` first.
+
+## Simple Chat (`simple_chat.py`)
+...

--- a/examples/multi-llm_chat.py
+++ b/examples/multi-llm_chat.py
@@ -9,7 +9,6 @@ To explore the contrast in worldviews, we present two opposing perspectives (tak
 These dialogues illustrate the deep philosophical divide between consequentialism and deontological ethics. Therefore that makes a great example for a simple chat application using two different LLMs: Mistral and Google AI Studio.
 """
 import os
-from dotenv import load_dotenv
 from mistralai import Mistral
 from google import genai
 
@@ -18,8 +17,6 @@ from memor import Prompt, Response
 from memor import Session
 from memor import Role, RenderFormat, LLMModel
 
-load_dotenv()
-
 session = Session(title="Ethical Debate") # Create a new session for the chat
 prompt = Prompt(
     message="Do the ends ever justify the means?",
@@ -27,7 +24,7 @@ prompt = Prompt(
 )
 
 # Setting up Mistral client
-MISTRAL_API_KEY = os.environ.get("MISTRAL_API_KEY", "YOUR_API_KEY")
+MISTRAL_API_KEY = "YOUR_MISTRAL_API_KEY"
 if not MISTRAL_API_KEY:
     raise ValueError("Please set the MISTRAL_API_KEY environment variable.")
 MISTRAL_MODEL = os.environ.get("MISTRAL_MODEL", "mistral-large-latest")
@@ -66,7 +63,7 @@ session.add_message(prompt)
 
 
 # Setting up Google AI Studio client
-GOOGLE_AI_STUDIO_API_KEY = os.environ.get("GOOGLE_AI_STUDIO_API_KEY", "YOUR_API_KEY")
+GOOGLE_AI_STUDIO_API_KEY = "YOUR_GOOGLE_AI_STUDIO_API_KEY"
 if not GOOGLE_AI_STUDIO_API_KEY:
     raise ValueError("Please set the GOOGLE_AI_STUDIO_API_KEY environment variable.")
 GOOGLE_AI_STUDIO_MODEL = os.environ.get("GOOGLE_AI_STUDIO_MODEL", "gemini-2.0-flash")

--- a/examples/multi-llm_chat.py
+++ b/examples/multi-llm_chat.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-"""Simple chat example
+"""Multi LLM chat example
 
 In this example, we're using one of the most controversial questions in human history: "Do the ends ever justify the means?"
 This question sits at the heart of countless ethical, political, philosophical debates, and modern policymaking.
 To explore the contrast in worldviews, we present two opposing perspectives (taken role by two LLMs).
 1. The first is an ethical idealist, who argues that the process matters just as much as — if not more than — the outcome, and that compromising principles undermines the integrity of any goal. We give this role to Mistral.
 2. The second is from a Machiavellian strategist, who believes that achieving a desirable outcome can legitimize morally ambiguous actions, prioritizing results over the path taken. We give this role to Google AI Studio.
-These dialogues illustrate the deep philosophical divide between consequentialism and deontological ethics. Therefore that makes a great example for a simple chat application using two different LLMs: Mistral and Google AI Studio.
+These dialogues illustrate the deep philosophical divide between consequentialism and deontological ethics. Therefore that makes a great example for a multi agent chat application using two different LLMs: Mistral and Google AI Studio.
 """
 import os
 from mistralai import Mistral

--- a/examples/multi-llm_chat.py
+++ b/examples/multi-llm_chat.py
@@ -8,7 +8,6 @@ To explore the contrast in worldviews, we present two opposing perspectives (tak
 2. The second is from a Machiavellian strategist, who believes that achieving a desirable outcome can legitimize morally ambiguous actions, prioritizing results over the path taken. We give this role to Google AI Studio.
 These dialogues illustrate the deep philosophical divide between consequentialism and deontological ethics. Therefore that makes a great example for a multi agent chat application using two different LLMs: Mistral and Google AI Studio.
 """
-import os
 from mistralai import Mistral
 from google import genai
 

--- a/examples/multi-llm_chat.py
+++ b/examples/multi-llm_chat.py
@@ -23,11 +23,8 @@ prompt = Prompt(
     role=Role.USER,
 )
 
-# Setting up Mistral client
 MISTRAL_API_KEY = "YOUR_MISTRAL_API_KEY"
-if not MISTRAL_API_KEY:
-    raise ValueError("Please set the MISTRAL_API_KEY environment variable.")
-MISTRAL_MODEL = os.environ.get("MISTRAL_MODEL", "mistral-large-latest")
+MISTRAL_MODEL = "mistral-large-latest"
 mistral_client = Mistral(api_key=MISTRAL_API_KEY)
 
 ethical_idealist_template = PromptTemplate(
@@ -64,9 +61,7 @@ session.add_message(prompt)
 
 # Setting up Google AI Studio client
 GOOGLE_AI_STUDIO_API_KEY = "YOUR_GOOGLE_AI_STUDIO_API_KEY"
-if not GOOGLE_AI_STUDIO_API_KEY:
-    raise ValueError("Please set the GOOGLE_AI_STUDIO_API_KEY environment variable.")
-GOOGLE_AI_STUDIO_MODEL = os.environ.get("GOOGLE_AI_STUDIO_MODEL", "gemini-2.0-flash")
+GOOGLE_AI_STUDIO_MODEL = "gemini-2.0-flash"
 gemini_client = genai.Client(api_key=GOOGLE_AI_STUDIO_API_KEY)
 
 machiavellian_strategist_template = PromptTemplate(

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,3 +1,2 @@
-python-dotenv
 google-genai
 mistralai

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,0 +1,3 @@
+python-dotenv
+google-genai
+mistralai

--- a/examples/simple_chat.py
+++ b/examples/simple_chat.py
@@ -1,11 +1,16 @@
 # -*- coding: utf-8 -*-
-"""Simple chat example
-In this example, we demonstrate a simple chat application which uses history of the chat session.
-In this example we use Mistral LLM to generate responses which is the same as OpenAI API LLM families."""
+"""
+Simple Chat Example with Mistral and Memor
+
+This script demonstrates a simple chat loop using the Mistral LLM and the Memor session/history system.
+It maintains chat history and renders it in OpenAI-compatible format.
+"""
+
+import os
 from pprint import pprint
 from mistralai import Mistral
-
 from memor import Prompt, Response, Session, Role, RenderFormat
+
 
 MISTRAL_API_KEY = "YOUR_MISTRAL_API_KEY"  # Replace with your Mistral API key
 MISTRAL_MODEL = "mistral-large-latest"

--- a/examples/simple_chat.py
+++ b/examples/simple_chat.py
@@ -1,44 +1,99 @@
 # -*- coding: utf-8 -*-
-"""Simple chat example"""
+"""Simple chat example
+
+In this example, we're using one of the most controversial questions in human history: "Do the ends ever justify the means?"
+This question sits at the heart of countless ethical, political, philosophical debates, and modern policymaking.
+To explore the contrast in worldviews, we present two opposing perspectives (taken role by two LLMs).
+1. The first is an ethical idealist, who argues that the process matters just as much as — if not more than — the outcome, and that compromising principles undermines the integrity of any goal. We give this role to Mistral.
+2. The second is from a Machiavellian strategist, who believes that achieving a desirable outcome can legitimize morally ambiguous actions, prioritizing results over the path taken. We give this role to Google AI Studio.
+These dialogues illustrate the deep philosophical divide between consequentialism and deontological ethics. Therefore that makes a great example for a simple chat application using two different LLMs: Mistral and Google AI Studio.
+"""
 import os
 from dotenv import load_dotenv
-
 from mistralai import Mistral
 from google import genai
 
 from memor import PromptTemplate
 from memor import Prompt, Response
 from memor import Session
-from memor import Role
+from memor import Role, RenderFormat, LLMModel
 
 load_dotenv()
+
+session = Session(title="Ethical Debate") # Create a new session for the chat
+prompt = Prompt(
+    message="Do the ends ever justify the means?",
+    role=Role.USER,
+)
+
+# Setting up Mistral client
 MISTRAL_API_KEY = os.environ.get("MISTRAL_API_KEY", "YOUR_API_KEY")
 if not MISTRAL_API_KEY:
     raise ValueError("Please set the MISTRAL_API_KEY environment variable.")
 MISTRAL_MODEL = os.environ.get("MISTRAL_MODEL", "mistral-large-latest")
+mistral_client = Mistral(api_key=MISTRAL_API_KEY)
 
-GOOGLE_API_KEY = os.environ.get("GOOGLE_API_KEY", "YOUR_API_KEY")
-if not GOOGLE_API_KEY:
-    raise ValueError("Please set the GOOGLE_API_KEY environment variable.")
-GOOGLE_MODEL = os.environ.get("GOOGLE_MODEL", "gemini-2.0-flash")
+ethical_idealist_template = PromptTemplate(
+    content="{instruction}\n\n{prompt[message]}",
+    custom_map={
+        "instruction": "You are an ethical idealist who believes that how we act matters just as much — if not more — than what we achieve."
+            "You value principles like honesty, justice, and human dignity, even when they complicate the path to success."})
 
-
-client = Mistral(api_key=MISTRAL_API_KEY)
-chat_response = client.chat.complete(
+prompt.update_template(ethical_idealist_template)
+chat_response = mistral_client.chat.complete(
     model = MISTRAL_MODEL,
-    messages = [
+    messages = [ #TODO: need change and use prompt.render(RenderFormat.OPENAI)
         {
-            "role": "user",
-            "content": "What is the best French cheese?",
+            "role": Role.SYSTEM.value,
+            "content": ethical_idealist_template.custom_map["instruction"]
         },
+        {
+            "role": Role.USER.value,
+            "content": prompt.message
+        }
     ]
 )
-print(chat_response.choices[0].message.content)
+for choice in chat_response.choices:
+    print(f"Mistral response: {choice.message.content}")
+    response = Response(
+        message=choice.message.content,
+        role=Role.ASSISTANT,
+        tokens=chat_response.usage.total_tokens,
+        model=chat_response.model,
+    )
+    prompt.add_response(response)
+session.add_message(prompt)
 
 
-client = genai.Client(api_key=GOOGLE_API_KEY)
-response = client.models.generate_content(
-    model=GOOGLE_MODEL,
-    contents="Explain how AI works in a few words"
+# Setting up Google AI Studio client
+GOOGLE_AI_STUDIO_API_KEY = os.environ.get("GOOGLE_AI_STUDIO_API_KEY", "YOUR_API_KEY")
+if not GOOGLE_AI_STUDIO_API_KEY:
+    raise ValueError("Please set the GOOGLE_AI_STUDIO_API_KEY environment variable.")
+GOOGLE_AI_STUDIO_MODEL = os.environ.get("GOOGLE_AI_STUDIO_MODEL", "gemini-2.0-flash")
+gemini_client = genai.Client(api_key=GOOGLE_AI_STUDIO_API_KEY)
+
+machiavellian_strategist_template = PromptTemplate(
+    content="{instruction}\n\n{prompt[message]}",
+    custom_map={
+        "instruction": "You are a pragmatic strategist inspired by Niccolò Machiavelli."
+            "You believe power, stability, and success often require morally ambiguous choices."
+            "You prioritize results over intentions and see ethical rules as tools, not absolutes."})
+
+prompt.update_template(machiavellian_strategist_template)
+
+chat_content = gemini_client.models.generate_content(
+    model=GOOGLE_AI_STUDIO_MODEL,
+    contents=prompt.render(RenderFormat.AI_STUDIO)
 )
-print(response.text)
+
+response = Response(
+    message=chat_content.text,
+    role=Role.ASSISTANT,
+    tokens=chat_response.usage.total_tokens,
+    model=LLMModel.GEMINI_2_FLASH,
+)
+prompt.add_response(response)
+session.add_message(prompt)
+
+session.save(f"{session.title.lower().replace(' ', '-')}.json")  # Save the session with all messages
+print(session)

--- a/examples/simple_chat.py
+++ b/examples/simple_chat.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""Simple chat example
+In this example, we demonstrate a simple chat application which uses history of the chat session.
+In this example we use Mistral LLM to generate responses which is the same as OpenAI API LLM families."""
+from pprint import pprint
+from mistralai import Mistral
+
+from memor import Prompt, Response, Session, Role, RenderFormat
+
+MISTRAL_API_KEY = "YOUR_MISTRAL_API_KEY"  # Replace with your Mistral API key
+MISTRAL_MODEL = "mistral-large-latest"
+mistral_client = Mistral(api_key=MISTRAL_API_KEY)
+
+session = Session(title="Simple Chat")
+while True:
+    try:
+        user_input = input("You: ")
+    except (EOFError, KeyboardInterrupt):
+        break
+
+    prompt = Prompt(
+        message=user_input,
+        role=Role.USER,
+    )
+    session.add_message(prompt)
+
+    response_content = mistral_client.chat.complete(
+        model=MISTRAL_MODEL,
+        messages=session.render(RenderFormat.OPENAI)  # Render the whole session history
+    ).choices[0].message.content
+    response = Response(
+        message=response_content,
+        role=Role.ASSISTANT,
+    )
+
+    print(f"LLM: {response.message}")
+    session.add_message(response)
+
+# you can now access the session history
+pprint(session.render(RenderFormat.OPENAI))

--- a/examples/simple_chat.py
+++ b/examples/simple_chat.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""Simple chat example"""
+import os
+from dotenv import load_dotenv
+
+from mistralai import Mistral
+from google import genai
+
+from memor import PromptTemplate
+from memor import Prompt, Response
+from memor import Session
+from memor import Role
+
+load_dotenv()
+MISTRAL_API_KEY = os.environ.get("MISTRAL_API_KEY", "YOUR_API_KEY")
+if not MISTRAL_API_KEY:
+    raise ValueError("Please set the MISTRAL_API_KEY environment variable.")
+MISTRAL_MODEL = os.environ.get("MISTRAL_MODEL", "mistral-large-latest")
+
+GOOGLE_API_KEY = os.environ.get("GOOGLE_API_KEY", "YOUR_API_KEY")
+if not GOOGLE_API_KEY:
+    raise ValueError("Please set the GOOGLE_API_KEY environment variable.")
+GOOGLE_MODEL = os.environ.get("GOOGLE_MODEL", "gemini-2.0-flash")
+
+
+client = Mistral(api_key=MISTRAL_API_KEY)
+chat_response = client.chat.complete(
+    model = MISTRAL_MODEL,
+    messages = [
+        {
+            "role": "user",
+            "content": "What is the best French cheese?",
+        },
+    ]
+)
+print(chat_response.choices[0].message.content)
+
+
+client = genai.Client(api_key=GOOGLE_API_KEY)
+response = client.models.generate_content(
+    model=GOOGLE_MODEL,
+    contents="Explain how AI works in a few words"
+)
+print(response.text)


### PR DESCRIPTION
#### Reference Issues/PRs
#115

#### What does this implement/fix? Explain your changes.
This PR adds two examples that showcase important features of memor. The examples are as such

- `simple_chat.py`: an example of a simple chat with an LLM (in this case, Mistral), which shows how users can leverage their chat history to include more information in it.
- `mutli-llm_chat.py`: an example of conversation with the same concepts among multiple LLMs using memor tools.

#### Any other comments?

